### PR TITLE
couple of minor changes to README and requirements for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ curl 'http://localhost:8983/solr/admin/cores?action=RELOAD&core=$SOLR_CORE'
 Then update the index itself:
 
 ```bash
-manage.py rebuild_search_index
+manage.py rebuild_index
 ```
 
 (It will take a couple of minutes to reindex fully.)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Tests in the project are generally high-level integration acceptance tests that 
 Make sure you have installed test dependencies and initialized the test database in [Setup](#setup) above. Then simply:
 
 ```bash
+mkdir coverage
 py.test
 ```
 

--- a/nuremberg/core/tests/requirements.txt
+++ b/nuremberg/core/tests/requirements.txt
@@ -1,7 +1,8 @@
+coverage==3.7.1
 pyquery==1.2.13
 pytest-django==2.9.1
 pytest-cov==2.2.1
-pytest-instafail-0.3.0
+pytest-instafail==0.3.0
 selenium==2.53.5
 sure==1.2.24
 


### PR DESCRIPTION
I got the application and tests working with only a few changes to the instructions. The version of coverage that got auto-installed didn't work, so I pinned it to 3.7.1 according to https://github.com/saltstack/salt-jenkins/pull/127