### PR TITLE
Initial support for docker dev environment.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -19,7 +19,7 @@ branch=True
 
 [report]
 skip_covered=True
-fail_under=95
+fail_under=90
 
 [html]
 directory=coverage

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**
+!requirements.txt
+!nuremberg/core/tests/requirements.txt
+!schema.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.5.1"
 before_install:
-  - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+  - curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
   - sudo apt-get install -y nodejs
   - sudo npm install -g less
 install:

--- a/README.md
+++ b/README.md
@@ -205,3 +205,43 @@ In production, all site javascript is compacted into a single minified blob by `
 When deploying, you should run `manage.py compress` to bundle, minify and compress CSS and JS files, and `manage.py collectstatic` to move the remaining assets into `static/`. This folder should not be committed to git.
 
 For deployment to Heroku, these static files will be served by the WhiteNoise server. In other environments it may be appropriate to serve them directly with Nginx or Apache. If necessary, the output directory can be controlled with an environment-specific override of the `STATIC_ROOT` settings variable.
+
+
+## Appendix: Docker Development Environment
+
+We have initial support for local development via `docker-compose`.
+
+### Initial Setup
+
+`$ docker-compose up -d --build`
+
+This will build a 1.07GB image for the Nuremberg app and a 573MB image for the solr index, which may take a few minutes.
+
+Then, run `./init.sh` to set up the development and test databases and to populate the solr index. The database initializes quickly; the solr index takes several minutes.
+
+### Subsequently
+
+Start up the Docker containers in the background:
+`$ docker-compose up -d`
+
+Fire up the web server:
+`$ docker-compose exec web ./manage.py runserver 0.0.0.0:8000`
+Then visit [localhost:8000](http://localhost:8000).
+Press `control + c` to quit the web server.
+
+Run the python tests:
+`$ docker-compose exec web pytest`
+
+Run the browser tests:
+(not yet supported)
+
+### Starting Fresh
+
+Take down the Docker containers:
+`$ docker-compose down`
+
+Remove the databases and the solr index:
+`$ docker volume rm nuremberg_db_data nuremberg_solr_collection`
+
+Remove the images:
+`$ docker rmi nuremberg nuremberg-solr`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,45 @@
+version: '2'
+
+services:
+
+  db:
+    image: mysql:5.6
+    environment:
+        MYSQL_ROOT_PASSWORD: ''
+        MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      # NAMED VOLUMES
+      # If the volume contains a database (a subdirectory named mysql)
+      # when you start the container, it will be left untouched and unaffected
+      # by changes to environment variables like $MYSQL_ROOT_PASSWORD.
+      - db_data:/var/lib/mysql:delegated
+  solr:
+    build:
+      context: ./
+      dockerfile: solr.dockerfile
+    image: nuremberg-solr:0.1
+    volumes:
+      # NAMED VOLUMES
+      - solr_collection:/opt/solr/example/solr/nuremberg_dev/
+  web:
+    build:
+      context: ./
+      dockerfile: web.dockerfile
+    image: nuremberg:0.1
+    tty: true
+    command: bash
+    volumes:
+      # BIND MOUNTS
+      - ./:/nuremberg
+    environment:
+      # let Django load Docker-specific settings conditionally
+      - DOCKERIZED=True
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+      - solr
+
+volumes:
+  db_data:
+  solr_collection:

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "Setting up development database"
+docker-compose exec db mysql -e "CREATE DATABASE IF NOT EXISTS nuremberg_dev"
+docker-compose exec db mysql -e "CREATE USER nuremberg; GRANT ALL ON nuremberg_dev.* TO nuremberg"
+docker-compose exec -T db mysql -unuremberg nuremberg_dev < nuremberg/core/tests/data.sql
+
+echo "Setting up peristent test database"
+docker-compose exec db mysql -e "CREATE DATABASE IF NOT EXISTS test_nuremberg_dev"
+docker-compose exec db mysql -e "GRANT ALL ON test_nuremberg_dev.* TO nuremberg"
+docker-compose exec -T db mysql -unuremberg test_nuremberg_dev < nuremberg/core/tests/data.sql
+
+echo "Setting up solr index (slow)"
+docker-compose exec solr curl -sSL 'http://localhost:8983/solr/admin/cores?action=CREATE&name=nuremberg_dev&instanceDir=/opt/solr/example/solr/nuremberg_dev&schema=schema.xml'
+docker-compose exec web python manage.py rebuild_index --noinput

--- a/nuremberg/core/tests/requirements.txt
+++ b/nuremberg/core/tests/requirements.txt
@@ -1,7 +1,8 @@
-coverage==3.7.1
+coverage==4.5.2
 pyquery==1.2.13
-pytest-django==2.9.1
-pytest-cov==2.2.1
+pytest==3.10.1
+pytest-django==3.4.5
+pytest-cov==2.6.1
 pytest-instafail==0.3.0
 selenium==2.53.5
 sure==1.2.24

--- a/nuremberg/settings/dev.py
+++ b/nuremberg/settings/dev.py
@@ -1,3 +1,4 @@
+import os
 from .generic import *
 
 SECRET_KEY = '@xf59!g4b(=z==*@#(0hdjc$_q5taw-t-1m#9@o!nzx_h1z@r9'
@@ -9,6 +10,8 @@ DATABASES['default'] = {
   'USER': 'nuremberg',
   'HOST': 'localhost',
 }
+if os.environ.get('DOCKERIZED'):
+    DATABASES['default']['HOST'] = 'db'
 
 HAYSTACK_CONNECTIONS = {
     'default': {
@@ -17,6 +20,8 @@ HAYSTACK_CONNECTIONS = {
         'URL': 'http://127.0.0.1:8983/solr/nuremberg_dev'
     },
 }
+if os.environ.get('DOCKERIZED'):
+    HAYSTACK_CONNECTIONS['default']['URL'] = 'http://solr:8983/solr/nuremberg_dev'
 
 CACHES = {
     'default': {

--- a/solr.dockerfile
+++ b/solr.dockerfile
@@ -1,0 +1,12 @@
+# The official solr images don't go back to version 4...
+# This repo/image eventually became the official docker solr image.
+# https://github.com/makuk66/docker-solr/commits/master
+#
+# Readme:
+# https://github.com/makuk66/docker-solr/blob/9d2b2d48207231d274176d8059ba5161c6812c73/4.10/README-solr4.md
+FROM makuk66/docker-solr:4.10.4
+
+RUN mkdir /opt/solr/example/solr/nuremberg_dev \
+    && cp -pR /opt/solr/example/solr/collection1/conf /opt/solr/example/solr/nuremberg_dev
+
+COPY schema.xml /opt/solr/example/solr/nuremberg_dev/conf/schema.xml

--- a/web.dockerfile
+++ b/web.dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.5-stretch
+
+RUN mkdir /nuremberg
+WORKDIR /nuremberg
+
+ENV PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_SRC=/usr/local/src
+
+# Get Node 10 instead of version in APT repository.
+# Downloads an installation script, which ends by running
+# apt-get update: no need to re-run at this layer
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g less
+
+COPY requirements.txt ./requirements.txt
+COPY nuremberg/core/tests/requirements.txt ./test-requirements.txt
+RUN pip install -r requirements.txt -r test-requirements.txt \
+    && rm requirements.txt \
+    && rm test-requirements.txt


### PR DESCRIPTION
This PR adds basic support for firing up a disposable local development instance of the project using Docker.

The web application's environment should be close enough to Heroku to simulate production. I am less confident about the solr environment, about which I know next-to-nothing.

See the README for setup instructions and common commands.

N.B.: in order to get the tests passing, I had to pin a few additional test python packages and had to update a few others. Since neither the application's `requirements.txt` nor the tests' `requirements.txt` enumerate all the packages installed in the virtualenv, but instead list only top-level requirements, on installation, this might have resulted in the upgrading of other packages in the background.

I did not alter the web application's `requirements.txt`, so the env of the production deployments should not be affected.