### PR TITLE
Update certifi

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -8,7 +8,7 @@ asgiref==3.5.2
     # via django
 attrs==22.1.0
     # via pytest
-certifi==2018.11.29
+certifi==2022.12.7
     # via requests
 chardet==3.0.4
     # via requests


### PR DESCRIPTION
This version of certifi removes TrustCor's root certificate. I haven't found release notes, but here's the diff from the previous version to this:

https://github.com/certifi/python-certifi/compare/2022.09.24...2022.12.07

(We're running an older package -- here's the [longer diff](https://github.com/certifi/python-certifi/compare/2018.11.29...2022.12.07).)